### PR TITLE
Support Django 2.0

### DIFF
--- a/cache_toolbox/middleware.py
+++ b/cache_toolbox/middleware.py
@@ -85,13 +85,14 @@ from django.contrib.auth.middleware import AuthenticationMiddleware
 from .model import cache_model
 
 class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware):
-    def __init__(self):
+    def __init__(self, get_response):
+        super(CacheBackedAuthenticationMiddleware, self).__init__(get_response)
         cache_model(User)
 
     def process_request(self, request):
         try:
             # Try and construct a User instance from data stored in the cache
             request.user = User.get_cached(int(request.session[SESSION_KEY]))
-        except:
+        except Exception:
             # Fallback to constructing the User from the database.
             super(CacheBackedAuthenticationMiddleware, self).process_request(request)

--- a/cache_toolbox/relation.py
+++ b/cache_toolbox/relation.py
@@ -102,7 +102,7 @@ def cache_relation(descriptor, timeout=None):
         except rel.related_model.DoesNotExist:
             raise descriptor.RelatedObjectDoesNotExist(
                 "%s has no %s." % (
-                    rel.to.__name__,
+                    rel.model.__name__,
                     related_name,
                 ),
             )
@@ -110,7 +110,7 @@ def cache_relation(descriptor, timeout=None):
         setattr(self, '_%s_cache' % related_name, instance)
 
         return instance
-    setattr(rel.to, related_name, get)
+    setattr(rel.model, related_name, get)
 
     # Clearing cache
 
@@ -124,8 +124,8 @@ def cache_relation(descriptor, timeout=None):
     def clear_cache(sender, instance, *args, **kwargs):
         delete_instance(rel.related_model, instance)
 
-    setattr(rel.to, '%s_clear' % related_name, clear)
-    setattr(rel.to, '%s_clear_pk' % related_name, clear_pk)
+    setattr(rel.model, '%s_clear' % related_name, clear)
+    setattr(rel.model, '%s_clear_pk' % related_name, clear_pk)
 
     post_save.connect(clear_cache, sender=rel.related_model, weak=False)
     post_delete.connect(clear_cache, sender=rel.related_model, weak=False)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(exclude=('tests',)),
 
     install_requires=(
-        "Django>=1.8,<2.1",
+        "Django>=1.9,<2.1",
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(exclude=('tests',)),
 
     install_requires=(
-        "Django>=1.8,<2.0",
+        "Django>=1.8,<2.1",
     ),
 )


### PR DESCRIPTION
Update to support Django 2.0

I've run the tests on 
- django 1.8 - failed `AttributeError: module 'django.db.transaction' has no attribute 'on_commit'` I think that was introduced by #6 
- django 1.9 - passed
- django 1.11 - passed
- django 2.0 - passed

For Django 2.0 compatibility I had to 
- update the middleware so that the parent class  `__init__` is called.

- https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0
details that `remote_field.to` has been removed. `model` is now the attribute to use.