### PR TITLE
Bump allowed Django version to <2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(exclude=('tests',)),
 
     install_requires=(
-        "Django>=1.9,<2.1",
+        "Django>=1.9,<2.2",
     ),
 )


### PR DESCRIPTION
This appears to work fine in practice on 2.1.