### PR TITLE
Support always fetching some relations when loading a model

### DIFF
--- a/cache_toolbox/core.py
+++ b/cache_toolbox/core.py
@@ -22,6 +22,14 @@ from . import app_settings
 CACHE_FORMAT_VERSION = 2
 
 
+def get_related_name(descriptor):
+    return '%s_cache' % descriptor.related.field.related_query_name()
+
+
+def get_related_cache_name(related_name: str) -> str:
+    return '_%s_cache' % related_name
+
+
 def serialise(instance):
     data = {}
     for field in instance._meta.fields:

--- a/cache_toolbox/relation.py
+++ b/cache_toolbox/relation.py
@@ -78,16 +78,20 @@ from .core import (
     delete_instance,
     get_related_name,
     get_related_cache_name,
+    add_always_fetch_relation,
 )
 
 
-def cache_relation(descriptor, timeout=None):
+def cache_relation(descriptor, timeout=None, *, always_fetch=False):
     rel = descriptor.related
 
     if not rel.field.primary_key:
         # This is an internal limitation due to the way that we construct our
         # cache keys.
         raise ValueError("Cached relations must be the primary key")
+
+    if always_fetch:
+        add_always_fetch_relation(descriptor)
 
     related_name = get_related_name(descriptor)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -17,3 +17,20 @@ class Bazz(models.Model):
 
 cache_model(Foo)
 cache_relation(Foo.bazz)
+
+
+class ToLoad(models.Model):
+    name = models.TextField()
+
+class AlwaysRelated(models.Model):
+    to_load = models.OneToOneField(
+        ToLoad,
+        related_name='always_related',
+        on_delete=models.CASCADE,
+        primary_key=True,
+    )
+
+    value = models.IntegerField(null=True)
+
+cache_model(ToLoad)
+cache_relation(ToLoad.always_related, always_fetch=True)

--- a/tests/test_cached_get_related.py
+++ b/tests/test_cached_get_related.py
@@ -1,0 +1,66 @@
+from django.core.cache import cache
+from django.test import TransactionTestCase
+
+from .models import AlwaysRelated, ToLoad
+
+
+# Use `TransactionTestCase` so that our `on_commit` actions happen when we expect.
+class CachedGetRelatedTest(TransactionTestCase):
+    def setUp(self):
+        self.to_load = ToLoad.objects.create(name='bees')
+        self.always_related = AlwaysRelated.objects.create(to_load=self.to_load)
+        self._populate_cache()
+
+    def _populate_cache(self):
+        ToLoad.get_cached(self.to_load.pk)
+
+    def test_cached_get(self):
+        # Get from the cache
+        cached_object = ToLoad.get_cached(self.to_load.pk)
+
+        # Validate that we're using the value we pre-loaded
+        cache.clear()
+
+        with self.assertNumQueries(0):
+            self.assertEqual(self.to_load.name, cached_object.name)
+            self.assertEqual(
+                self.always_related,
+                cached_object.always_related_cache,
+            )
+
+    def test_cached_get_no_relation(self):
+        self.always_related.delete()
+
+        # Get from the cache
+        cached_object = ToLoad.get_cached(self.to_load.pk)
+
+        self.assertEqual(self.to_load.name, cached_object.name)
+
+        with self.assertNumQueries(0):
+            with self.assertRaises(AlwaysRelated.DoesNotExist):
+                cached_object.always_related_cache
+
+        # Sanity check
+        with self.assertNumQueries(1):
+            with self.assertRaises(AlwaysRelated.DoesNotExist):
+                cached_object.always_related
+
+    def test_cached_get_no_relation_no_cache(self):
+        self.always_related.delete()
+        cache.clear()
+
+        # Attempt to load, should fall back to the database and should handle
+        # the lack of the related instance.
+        with self.assertNumQueries(1):
+            cached_object = ToLoad.get_cached(self.to_load.pk)
+
+        self.assertEqual(self.to_load.name, cached_object.name)
+
+        with self.assertNumQueries(0):
+            with self.assertRaises(AlwaysRelated.DoesNotExist):
+                cached_object.always_related_cache
+
+        # Sanity check
+        with self.assertNumQueries(0):
+            with self.assertRaises(AlwaysRelated.DoesNotExist):
+                cached_object.always_related


### PR DESCRIPTION
This aims to allow cache lookups for a model and its relations to be done in batch, akin to `select_related`, where it's known ahead of time that the relations will be needed.

For example, given models like:
``` python
class User(Model):
    pass
class Arm(Model):
    user = ForeignKey(User, ...)
```
with this PR, their relation caching could be arranged like:
``` python
cache_relation(User.arm, always_fetch=True)
```
then when `User` is loaded the related models are loaded too, thus:
``` python
User.get_cached(pk).arm_cache
```
only makes a single request in the happy path.

In the case of a cache miss this would still make only a single database request (using `select_related`) before populating all the results back into the cache.

With only a small number of relations this may not seem like a big saving, however if you've got several relations which are all always loaded this potentially saves quite a few queries.


Fixes https://github.com/lamby/django-cache-toolbox/issues/21

Note: no documentation changes yet. Would be great to have a discussion on the API (see below) before I do those.

---

As with #26 (and particularly bearing in mind the potential overlap with those changes) I'm not sure about the ideal API here -- obviously changing `cache_relation` _works_, but whether it's better to have this there or as part of `cache_model` (or even a separate API) is not clear to me.

One definite advantage to putting this on `cache_relation` is that it avoids circular imports that having it on `cache_model` might encounter. Having all the fetches listed on the single `cache_model` call could be better for clarity though.